### PR TITLE
Acknowledgement feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ Add a xray-checker to your system:
 
 ## Configuration
 These are the currently supported properties:
+```clojure
+			:yourchecker-check-environments "env1;env2;env3" ;the envs where you want to execute your checks
+			:yourchecker-check-frequency "60000" ;schedule for executing the checks in ms (execution is done in parallel)
+			:yourchecker-check-endpoint "/xray-checker" ;where the ui shows up
+			:yourchecker-max-check-history "100" ;nr of checks to keep (in memory)
+			:yourchecker-nr-checks-displayed "5" ;nr checks to be diplayed for a check/env on /xray-checker/overview
+			:yourchecker-acknowledge-hours-to-expire 1 ;time for acknowledgements in hours, default is 24 (one day)
+```			
 
-			yourchecker-check-environments=env1;env2;env3 ;the envs where you want to execute your checks
-			yourchecker-check-frequency=60000 ;schedule for executing the checks in ms (execution is done in parallel)
-			yourchecker-check-endpoint=/xray-checker ;where the ui shows up
-			yourchecker-max-check-history=100 ;nr of checks to keep (in memory)
-			yourchecker-nr-checks-displayed=5 ;nr checks to be diplayed for a check/env on /xray-checker/overview
-			
 ## UI
 ### Endpoint: /
 ![Example view of tesla-xray](doc/overall-status.png)
@@ -84,6 +86,19 @@ These are the currently supported properties:
 ### Endpoint: /detail/CheckC/test
 ![Example view of tesla-xray](doc/detailview.png)
 
+
+## Acknowledgement
+
+You are able to acknowledge checks that have an error by clicking on the check header in the detail view.
+ Acknowledgement lasts until it expires (default: one day, see config) or the check turns ok again.
+
+Endpoints for acknowledgement:
+* `/acknowledged-checks` GET: show all acknowledged checks and their expiration time
+* `/acknowledged-checks` POST: set new acknowledgement, parameters are: 
+    * `check-name` name of check to acknowledge
+    * `environment` in which environment the check should be acknowledged
+    *   `hours` acknowledgement time (in hours)
+* `/acknowledged-checks/<check-name>/<environment>` DELETE: delete acknowledgement for the check and environment specified in url
 
 ## Initial Contributors
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-xray "0.3.26"
+(defproject de.otto/tesla-xray "0.4.0"
   :description "a component to execute and visualize checks written in clj"
   :url "https://github.com/otto-de/tesla-xray.git"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   :profiles {:dev {:plugins      [[lein-ancient "0.6.10"][lein-release/lein-release "1.0.9"]]
                    :main de.otto.tesla.xray.testsystem
                    :source-paths ["src" "test"]
-                   :dependencies [[de.otto/tesla-microservice "0.3.36"]
+                   :dependencies [[de.otto/tesla-microservice "0.5.2"]
                                   [me.lomin/component-restart "0.1.1"]
                                   [de.otto/tesla-jetty "0.1.2"]
                                   [ring-mock "0.1.5"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-xray "0.3.26"
+(defproject de.otto/tesla-xray "0.3.26-SNAPSHOT"
   :description "a component to execute and visualize checks written in clj"
   :url "https://github.com/otto-de/tesla-xray.git"
   :license {:name "Apache License 2.0"
@@ -9,7 +9,8 @@
                  [ring/ring-codec "1.0.1"]
                  [clj-time "0.12.0"]]
   :test-paths ["test" "test-resources"]
-  :profiles {:dev {:plugins      [[lein-ancient "0.6.10"]]
+  :lein-release {:deploy-via :clojars}
+  :profiles {:dev {:plugins      [[lein-ancient "0.6.10"][lein-release/lein-release "1.0.9"]]
                    :main de.otto.tesla.xray.testsystem
                    :source-paths ["src" "test"]
                    :dependencies [[de.otto/tesla-microservice "0.3.36"]

--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -4,6 +4,13 @@ function onAcknowledgementClick(xrayUrl, check, environment, minutes) {
     var http = new XMLHttpRequest();
     http.open('POST', xrayUrl+'/acknowledged-checks');
     http.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+
+    http.onreadystatechange = function()
+        {
+            if (http.readyState == 4)
+            {
+                location.reload();
+            }
+        };
     http.send(params);
-    location.reload();
 }

--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -1,5 +1,5 @@
-function onAcknowledgementClick(xrayUrl, check, minutes) {
-    var params = "check-name="+check+"&minutes="+minutes;
+function onAcknowledgementClick(xrayUrl, check, environment, minutes) {
+    var params = "check-name="+check+"&environment="+environment+"&minutes="+minutes;
 
     var http = new XMLHttpRequest();
     http.open('POST', xrayUrl+'/acknowledged-checks');

--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -1,0 +1,9 @@
+function onAcknowledgementClick(xrayUrl, check, minutes) {
+    var params = "check-name="+check+"&minutes="+minutes;
+
+    var http = new XMLHttpRequest();
+    http.open('POST', xrayUrl+'/acknowledged-checks');
+    http.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+    http.send(params);
+    location.reload();
+}

--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -1,5 +1,5 @@
-function onAcknowledgementClick(xrayUrl, check, environment, minutes) {
-    var params = "check-name="+check+"&environment="+environment+"&minutes="+minutes;
+function onAcknowledgementClick(xrayUrl, check, environment, hours) {
+    var params = "check-name="+check+"&environment="+environment+"&hours="+hours;
 
     var http = new XMLHttpRequest();
     http.open('POST', xrayUrl+'/acknowledged-checks');

--- a/resources/public/stylesheets/base.css
+++ b/resources/public/stylesheets/base.css
@@ -23,6 +23,13 @@ body {
     background-color: rgba(0, 255, 127, 0.35);
 }
 
+.acknowledged {
+    background-color: #49A8FF;
+    font-size: 20px;
+    color: darkgray;
+    background-color: rgba(73, 168, 255, 1);
+}
+
 .env-header.error {
     background-color: rgba(255, 0, 0, 1);
 }

--- a/resources/public/stylesheets/base.css
+++ b/resources/public/stylesheets/base.css
@@ -35,7 +35,7 @@ body {
 }
 
 .single-check-results .env-header.error:hover {
-    background-color: #49A8FF;
+    background-color: #64CFFF;
 }
 
 .env-header.ok {
@@ -44,6 +44,10 @@ body {
 
 .env-header.warning {
     background-color: rgba(255, 249, 34, 1);
+}
+
+.env-header.acknowledged {
+    background-color: rgba(100, 207, 255, 1);
 }
 
 .none {

--- a/resources/public/stylesheets/base.css
+++ b/resources/public/stylesheets/base.css
@@ -26,12 +26,16 @@ body {
 .acknowledged {
     background-color: #49A8FF;
     font-size: 20px;
-    color: darkgray;
+    color: #2c3e50;
     background-color: rgba(73, 168, 255, 1);
 }
 
 .env-header.error {
     background-color: rgba(255, 0, 0, 1);
+}
+
+.single-check-results .env-header.error:hover {
+    background-color: #49A8FF;
 }
 
 .env-header.ok {
@@ -83,6 +87,9 @@ div.overall-warning {
 }
 div.overall-error {
     border: solid red 1px;
+}
+div.overall-acknowledged {
+    border: solid #49A8FF 1px;
 }
 
 div.env-results-container {

--- a/resources/public/stylesheets/overall-status.css
+++ b/resources/public/stylesheets/overall-status.css
@@ -1,7 +1,7 @@
 div.overall-status-page {
     width: 100%;
     height: 100%;
-    font-size: 500px;
+    font-size: 30vw;
     text-decoration: none;
     color: black;
     text-align: center;
@@ -22,5 +22,11 @@ a {
 }
 
 .overall-status-page.warning {
+    font-size: 23vw;
     background-color: rgba(255, 249, 34, 1);
+}
+
+.overall-status-page.acknowledged {
+    font-size: 14vw;
+    background-color: rgba(73, 168, 255, 1);
 }

--- a/resources/public/stylesheets/overall-status.css
+++ b/resources/public/stylesheets/overall-status.css
@@ -28,5 +28,5 @@ a {
 
 .overall-status-page.acknowledged {
     font-size: 14vw;
-    background-color: rgba(73, 168, 255, 1);
+    background-color: rgba(100, 207, 255, 1);
 }

--- a/src/de/otto/tesla/xray/conf/reading_properties.clj
+++ b/src/de/otto/tesla/xray/conf/reading_properties.clj
@@ -18,3 +18,5 @@
 (defn parse-nr-checks-displayed [config which-checker]
   (Integer/parseInt (get-in config [:config (keyword (str which-checker "-nr-checks-displayed"))] "5")))
 
+(defn parse-minutes-to-expire [config which-checker]
+  (get-in config [:config (keyword (str which-checker "-acknowledge-minutes-to-expire"))] (* 60 24)))

--- a/src/de/otto/tesla/xray/conf/reading_properties.clj
+++ b/src/de/otto/tesla/xray/conf/reading_properties.clj
@@ -18,5 +18,5 @@
 (defn parse-nr-checks-displayed [config which-checker]
   (Integer/parseInt (get-in config [:config (keyword (str which-checker "-nr-checks-displayed"))] "5")))
 
-(defn parse-minutes-to-expire [config which-checker]
-  (get-in config [:config (keyword (str which-checker "-acknowledge-minutes-to-expire"))] (* 60 24)))
+(defn parse-hours-to-expire [config which-checker]
+  (get-in config [:config (keyword (str which-checker "-acknowledge-hours-to-expire"))] 24))

--- a/src/de/otto/tesla/xray/ui/detail_page.clj
+++ b/src/de/otto/tesla/xray/ui/detail_page.clj
@@ -8,7 +8,7 @@
     (if-let [result-map (get-in @check-results [check-name current-env])]
       [:div {:class "single-check-results"}
        (eo/render-results-for-env 1 max-check-history check-name endpoint show-links [current-env result-map]
-                                  (str "onAcknowledgementClick(\"" endpoint "\", \"" check-name "\", " acknowledge-minutes-to-expire ")"))]
+                                  (str "onAcknowledgementClick(\"" endpoint "\", \"" check-name "\", \"" current-env "\", " acknowledge-minutes-to-expire ")"))]
       [:div "NO DATA FOUND"])))
 
 (defn render-detail-page [check-results {:keys [endpoint refresh-frequency] :as xray-config} check-name current-env]

--- a/src/de/otto/tesla/xray/ui/detail_page.clj
+++ b/src/de/otto/tesla/xray/ui/detail_page.clj
@@ -3,24 +3,26 @@
             [de.otto.tesla.xray.ui.env-overview :as eo]
             [clojure.java.io :as io]))
 
-(defn render-check-results [check-results {:keys [max-check-history endpoint]} check-name current-env]
+(defn render-check-results [check-results {:keys [max-check-history endpoint acknowledge-minutes-to-expire]} check-name current-env]
   (let [show-links false]
     (if-let [result-map (get-in @check-results [check-name current-env])]
       [:div {:class "single-check-results"}
-       (eo/render-results-for-env 1 max-check-history check-name endpoint show-links [current-env result-map])]
+       (eo/render-results-for-env 1 max-check-history check-name endpoint show-links [current-env result-map]
+                                  (str "onAcknowledgementClick(\"" endpoint "\", \"" check-name "\", " acknowledge-minutes-to-expire ")"))]
       [:div "NO DATA FOUND"])))
 
 (defn render-detail-page [check-results {:keys [endpoint refresh-frequency] :as xray-config} check-name current-env]
   (hc/html5
     [:head
      [:meta {:charset "utf-8"}]
-     [:meta {:http-equiv "refresh" :content (/ refresh-frequency  1000) }]
+     [:meta {:http-equiv "refresh" :content (/ refresh-frequency 1000)}]
      [:title "XRayCheck Results"]
+     (hc/include-js "/js/main.js")
      (hc/include-css "/stylesheets/base.css")
      (when (io/resource "public/stylesheets/custom.css")
        (hc/include-css "/stylesheets/custom.css"))]
     [:body
      [:header
-       [:h1 [:a {:class "index-link" :href (str endpoint"/overview")}"<-"] check-name]]
+      [:h1 [:a {:class "index-link" :href (str endpoint "/overview")} "<-"] check-name]]
      [:div {:class ""}
       (render-check-results check-results xray-config check-name current-env)]]))

--- a/src/de/otto/tesla/xray/ui/detail_page.clj
+++ b/src/de/otto/tesla/xray/ui/detail_page.clj
@@ -4,11 +4,12 @@
             [clojure.java.io :as io]))
 
 (defn render-check-results [check-results {:keys [max-check-history endpoint acknowledge-hours-to-expire]} check-name current-env]
-  (let [show-links false]
+  (let [show-links false
+        on-click-handler (str "onAcknowledgementClick(\"" endpoint "\", \"" check-name "\", \"" current-env "\", " acknowledge-hours-to-expire ")")]
     (if-let [result-map (get-in @check-results [check-name current-env])]
       [:div {:class "single-check-results"}
        (eo/render-results-for-env 1 max-check-history check-name endpoint show-links [current-env result-map]
-                                  (str "onAcknowledgementClick(\"" endpoint "\", \"" check-name "\", \"" current-env "\", " acknowledge-hours-to-expire ")"))]
+                                  :on-click on-click-handler)]
       [:div "NO DATA FOUND"])))
 
 (defn render-detail-page [check-results {:keys [endpoint refresh-frequency] :as xray-config} check-name current-env]

--- a/src/de/otto/tesla/xray/ui/detail_page.clj
+++ b/src/de/otto/tesla/xray/ui/detail_page.clj
@@ -3,12 +3,12 @@
             [de.otto.tesla.xray.ui.env-overview :as eo]
             [clojure.java.io :as io]))
 
-(defn render-check-results [check-results {:keys [max-check-history endpoint acknowledge-minutes-to-expire]} check-name current-env]
+(defn render-check-results [check-results {:keys [max-check-history endpoint acknowledge-hours-to-expire]} check-name current-env]
   (let [show-links false]
     (if-let [result-map (get-in @check-results [check-name current-env])]
       [:div {:class "single-check-results"}
        (eo/render-results-for-env 1 max-check-history check-name endpoint show-links [current-env result-map]
-                                  (str "onAcknowledgementClick(\"" endpoint "\", \"" check-name "\", \"" current-env "\", " acknowledge-minutes-to-expire ")"))]
+                                  (str "onAcknowledgementClick(\"" endpoint "\", \"" check-name "\", \"" current-env "\", " acknowledge-hours-to-expire ")"))]
       [:div "NO DATA FOUND"])))
 
 (defn render-detail-page [check-results {:keys [endpoint refresh-frequency] :as xray-config} check-name current-env]

--- a/src/de/otto/tesla/xray/ui/env_overview.clj
+++ b/src/de/otto/tesla/xray/ui/env_overview.clj
@@ -18,19 +18,18 @@
       the-html)))
 
 (defn render-results-for-env
-  ([total-cols nr-checks-displayed checkname endpoint show-links? env-result-map-pair]
-   (render-results-for-env total-cols nr-checks-displayed checkname endpoint show-links? env-result-map-pair ""))
-  ([total-cols nr-checks-displayed checkname endpoint show-links? [env {:keys [results overall-status]}] onClick]
-                              (let [width (int (/ 97 total-cols))
-                                    padding (int (/ 3 total-cols))
-                                    should-show-links? (and
-                                                         (not (= overall-status :none))
-                                                         show-links?)]
-                                (-> [:div {:class "env-results-container" :style (str "width: " width "%; padding-left: " padding "%;")}
-                                     [:div {:class (str "overall-" (name overall-status))}
-                                      [:div {:class (str "env-header " (name overall-status)) :onClick onClick} env]
-                                      (map single-check-result-as-html (take nr-checks-displayed results))]]
-                                    (wrapped-with-links-to-detail-page should-show-links? endpoint checkname env)))))
+  [total-cols nr-checks-displayed checkname endpoint show-links? [env {:keys [results overall-status]}] & {:keys [on-click]
+                                                                                                           :or   {on-click ""}}]
+  (let [width (int (/ 97 total-cols))
+        padding (int (/ 3 total-cols))
+        should-show-links? (and
+                             (not (= overall-status :none))
+                             show-links?)]
+    (-> [:div {:class "env-results-container" :style (str "width: " width "%; padding-left: " padding "%;")}
+         [:div {:class (str "overall-" (name overall-status))}
+          [:div {:class (str "env-header " (name overall-status)) :onClick on-click} env]
+          (map single-check-result-as-html (take nr-checks-displayed results))]]
+        (wrapped-with-links-to-detail-page should-show-links? endpoint checkname env))))
 
 (defn- sort-results-by-env [results-for-env environments]
   (sort-by (fn [[env _]] (.indexOf environments env)) results-for-env))
@@ -51,7 +50,7 @@
   (hc/html5
     [:head
      [:meta {:charset "utf-8"}]
-     [:meta {:http-equiv "refresh" :content (/ refresh-frequency  1000) }]
+     [:meta {:http-equiv "refresh" :content (/ refresh-frequency 1000)}]
      [:title "XRayCheck Results"]
      (hc/include-css "/stylesheets/base.css")
      (when (io/resource "public/stylesheets/custom.css")

--- a/src/de/otto/tesla/xray/ui/env_overview.clj
+++ b/src/de/otto/tesla/xray/ui/env_overview.clj
@@ -17,17 +17,20 @@
       [:a {:href (str endpoint "/detail/" url-ecoded-check-name "/" url-encoded-env)} the-html]
       the-html)))
 
-(defn render-results-for-env [total-cols nr-checks-displayed checkname endpoint show-links? [env {:keys [results overall-status]}]]
-  (let [width (int (/ 97 total-cols))
-        padding (int (/ 3 total-cols))
-        should-show-links? (and
-                             (not (= overall-status :none))
-                             show-links?)]
-    (-> [:div {:class "env-results-container" :style (str "width: " width "%; padding-left: " padding "%;")}
-         [:div {:class (str "overall-" (name overall-status))}
-          [:div {:class (str "env-header " (name overall-status))} env]
-          (map single-check-result-as-html (take nr-checks-displayed results))]]
-        (wrapped-with-links-to-detail-page should-show-links? endpoint checkname env))))
+(defn render-results-for-env
+  ([total-cols nr-checks-displayed checkname endpoint show-links? env-result-map-pair]
+   (render-results-for-env total-cols nr-checks-displayed checkname endpoint show-links? env-result-map-pair ""))
+  ([total-cols nr-checks-displayed checkname endpoint show-links? [env {:keys [results overall-status]}] onClick]
+                              (let [width (int (/ 97 total-cols))
+                                    padding (int (/ 3 total-cols))
+                                    should-show-links? (and
+                                                         (not (= overall-status :none))
+                                                         show-links?)]
+                                (-> [:div {:class "env-results-container" :style (str "width: " width "%; padding-left: " padding "%;")}
+                                     [:div {:class (str "overall-" (name overall-status))}
+                                      [:div {:class (str "env-header " (name overall-status)) :onClick onClick} env]
+                                      (map single-check-result-as-html (take nr-checks-displayed results))]]
+                                    (wrapped-with-links-to-detail-page should-show-links? endpoint checkname env)))))
 
 (defn- sort-results-by-env [results-for-env environments]
   (sort-by (fn [[env _]] (.indexOf environments env)) results-for-env))

--- a/src/de/otto/tesla/xray/ui/overall_status.clj
+++ b/src/de/otto/tesla/xray/ui/overall_status.clj
@@ -13,13 +13,12 @@
 
 (defn calc-overall-status [check-results last-check refresh-frequency]
   (let [all-status (map :overall-status (flat-results check-results))]
-    (if (no-check-started-for-too-long-time last-check refresh-frequency)
-      :defunct
-      (if (some #(= :error %) all-status)
-        :error
-        (if (some #(= :warning %) all-status)
-          :warning
-          :ok)))))
+    (cond
+      (no-check-started-for-too-long-time last-check refresh-frequency) :defunct
+      (some #(= :error %) all-status) :error
+      (some #(= :warning %) all-status) :warning
+      (some #(= :acknowledged %) all-status) :acknowledged
+      :default :ok)))
 
 (defn render-overall-status-container [check-results last-check {:keys [refresh-frequency endpoint]}]
   (let [the-overall-status (name (calc-overall-status check-results last-check refresh-frequency))]

--- a/src/de/otto/tesla/xray/xray_checker.clj
+++ b/src/de/otto/tesla/xray/xray_checker.clj
@@ -172,11 +172,12 @@
     (log/info "-> starting XrayChecker")
     (let [executor (at/mk-pool)
           new-self (assoc self
-                     :xray-config {:refresh-frequency   (props/parse-refresh-frequency config which-checker)
-                                   :nr-checks-displayed (props/parse-nr-checks-displayed config which-checker)
-                                   :max-check-history   (props/parse-max-check-history config which-checker)
-                                   :endpoint            (props/parse-endpoint config which-checker)
-                                   :environments        (props/parse-check-environments config which-checker)}
+                     :xray-config {:refresh-frequency             (props/parse-refresh-frequency config which-checker)
+                                   :nr-checks-displayed           (props/parse-nr-checks-displayed config which-checker)
+                                   :max-check-history             (props/parse-max-check-history config which-checker)
+                                   :endpoint                      (props/parse-endpoint config which-checker)
+                                   :environments                  (props/parse-check-environments config which-checker)
+                                   :acknowledge-minutes-to-expire (props/parse-minutes-to-expire config which-checker)}
                      :executor executor
                      :alerting-fn (atom nil)
                      :last-check (atom nil)

--- a/src/de/otto/tesla/xray/xray_checker.clj
+++ b/src/de/otto/tesla/xray/xray_checker.clj
@@ -136,12 +136,12 @@
         (comp/GET endpoint []
           {:status  200
            :headers {"Content-Type" "text/html"}
-           :body    (oas/render-overall-status check-results last-check xray-config)})
+           :body    (oas/render-overall-status check-results last-check xray-config)}
 
-        (comp/GET (str endpoint "/overview") []
-          {:status  200
-           :headers {"Content-Type" "text/html"}
-           :body    (eo/render-env-overview check-results last-check xray-config)})
+          (comp/GET (str endpoint "/overview") []
+            {:status  200
+             :headers {"Content-Type" "text/html"}
+             :body    (eo/render-env-overview check-results last-check xray-config)}))
 
         (comp/GET (str endpoint "/detail/:check-name/:environment") [check-name environment]
           {:status  200
@@ -150,18 +150,20 @@
 
         (comp/GET (str endpoint "/acknowledged-checks") []
           {:status  200
-           :headers {"Content-Type" "text/plain"}
+           :headers {"Content-Type" "application/json"}
            :body    (stringify-acknowledged-checks acknowledged-checks)})
 
         (comp/POST (str endpoint "/acknowledged-checks") [check-name environment minutes]
+          (acknowledge-check! acknowledged-checks check-name environment minutes)
           {:status  200
            :headers {"Content-Type" "text/plain"}
-           :body    (acknowledge-check! acknowledged-checks check-name environment minutes)})
+           :body ""})
 
         (comp/DELETE (str endpoint "/acknowledged-checks/:check-name") [check-name environment]
+          (remove-acknowledgement! acknowledged-checks check-name environment)
           {:status  200
            :headers {"Content-Type" "text/plain"}
-           :body    (remove-acknowledgement! acknowledged-checks check-name environment)})
+           :body ""})
         ))))
 
 

--- a/src/de/otto/tesla/xray/xray_checker.clj
+++ b/src/de/otto/tesla/xray/xray_checker.clj
@@ -158,13 +158,13 @@
 
         (comp/POST (str endpoint "/acknowledged-checks") [check-name environment hours]
           (acknowledge-check! check-results acknowledged-checks check-name environment hours)
-          {:status  200
+          {:status  204
            :headers {"Content-Type" "text/plain"}
            :body    ""})
 
         (comp/DELETE (str endpoint "/acknowledged-checks/:check-name/:environment") [check-name environment]
           (remove-acknowledgement! acknowledged-checks check-name environment)
-          {:status  200
+          {:status  204
            :headers {"Content-Type" "text/plain"}
            :body    ""})
         ))))

--- a/src/de/otto/tesla/xray/xray_checker.clj
+++ b/src/de/otto/tesla/xray/xray_checker.clj
@@ -159,7 +159,7 @@
            :headers {"Content-Type" "text/plain"}
            :body ""})
 
-        (comp/DELETE (str endpoint "/acknowledged-checks/:check-name") [check-name environment]
+        (comp/DELETE (str endpoint "/acknowledged-checks/:check-name/:environment") [check-name environment]
           (remove-acknowledgement! acknowledged-checks check-name environment)
           {:status  200
            :headers {"Content-Type" "text/plain"}

--- a/src/de/otto/tesla/xray/xray_checker.clj
+++ b/src/de/otto/tesla/xray/xray_checker.clj
@@ -115,8 +115,9 @@
       (update-results! self xray-check current-env (deref f)))
     (reset! last-check (utils/current-time))))
 
-(defn acknowledge-check! [acknowledged-checks check-name duration]
-  (swap! acknowledged-checks assoc check-name (+ (Integer/parseInt duration) (utils/current-time)))
+(defn acknowledge-check! [acknowledged-checks check-name duration-in-min]
+  (let [duration-in-ms (* 60 1000 (Long/parseLong duration-in-min))]
+    (swap! acknowledged-checks assoc check-name (+ duration-in-ms (utils/current-time))))
   (print @acknowledged-checks))
 
 (defn remove-acknowledgement! [acknowledged-checks check-name]
@@ -150,10 +151,10 @@
            :headers {"Content-Type" "text/plain"}
            :body    (stringify-acknowledged-checks acknowledged-checks)})
 
-        (comp/POST (str endpoint "/acknowledged-checks") [check-name duration]
+        (comp/POST (str endpoint "/acknowledged-checks") [check-name minutes]
           {:status  200
            :headers {"Content-Type" "text/plain"}
-           :body    (acknowledge-check! acknowledged-checks check-name duration)})
+           :body    (acknowledge-check! acknowledged-checks check-name minutes)})
 
         (comp/DELETE (str endpoint "/acknowledged-checks/:check-name") [check-name]
           {:status  200

--- a/src/de/otto/tesla/xray/xray_checker.clj
+++ b/src/de/otto/tesla/xray/xray_checker.clj
@@ -13,8 +13,7 @@
             [de.otto.tesla.stateful.handler :as hndl]
             [de.otto.tesla.xray.check :as chk]
             [clojure.data.json :as json])
-  (:import (org.joda.time DateTime)
-           (org.joda.time.format DateTimeFormat)))
+  (:import (org.joda.time.format DateTimeFormat)))
 
 (defprotocol XRayCheckerProtocol
   (set-alerting-function [self alerting-fn])
@@ -131,11 +130,17 @@
   (swap! acknowledged-checks update check-name dissoc environment)
   (swap! acknowledged-checks (fn [x] (into {} (filter #(not-empty (second %)) x)))))
 
+(defn as-date-time [millis]
+  (DateTime. millis))
+
+(defn as-readable-time [millis]
+  (.toString (as-date-time millis) (DateTimeFormat/forPattern "d MMMM, hh:mm")))
 
 (defn stringify-acknowledged-checks [acknowledged-checks]
-  (let [format-time (fn [_ value] (if (number? value)
-                                    (.toString (DateTime. value) (DateTimeFormat/forPattern "d MMMM, hh:mm"))
-                                    value))]
+  (let [format-time (fn [_ value]
+                      (if (number? value)
+                        (as-readable-time value)
+                        value))]
     (json/write-str @acknowledged-checks :value-fn format-time)))
 
 (defn- xray-routes [{:keys [check-results last-check xray-config acknowledged-checks]}]

--- a/src/de/otto/tesla/xray/xray_checker.clj
+++ b/src/de/otto/tesla/xray/xray_checker.clj
@@ -13,7 +13,8 @@
             [de.otto.tesla.stateful.handler :as hndl]
             [de.otto.tesla.xray.check :as chk]
             [clojure.data.json :as json])
-  (:import (org.joda.time.format DateTimeFormat)))
+  (:import (org.joda.time.format DateTimeFormat)
+           (org.joda.time DateTime)))
 
 (defprotocol XRayCheckerProtocol
   (set-alerting-function [self alerting-fn])

--- a/test/de/otto/tesla/xray/xraychecker_test.clj
+++ b/test/de/otto/tesla/xray/xraychecker_test.clj
@@ -247,8 +247,13 @@
   (testing "should put a check object with correct expire time in the acknowledged-checks atom"
     (with-redefs [utils/current-time (constantly 10)]
       (let [acknowledged-checks (atom {})]
-        (chkr/acknowledge-check! acknowledged-checks "tenMsLongAcknowledgement" "10")
-        (is (= ["tenMsLongAcknowledgement" 20] (first @acknowledged-checks))))))
+        (chkr/acknowledge-check! acknowledged-checks "oneHourAcknowledgement" "60")
+        (is (= ["oneHourAcknowledgement" (+ 10 (* 60 60 1000))] (first @acknowledged-checks))))))
+  (testing "should work for long expiry times"
+    (with-redefs [utils/current-time (constantly 10)]
+      (let [acknowledged-checks (atom {})]
+        (chkr/acknowledge-check! acknowledged-checks "oneYearAcknowledgement" (str (* 60 24 365)))
+        (is (= ["oneYearAcknowledgement" (+ 10 (* 365 24 60 60 1000))] (first @acknowledged-checks))))))
 
   (testing "should remove a check object regardless of it's expire time"
     (let [acknowledged-checks (atom {"checkToBeRemoved" 1000})]

--- a/test/de/otto/tesla/xray/xraychecker_test.clj
+++ b/test/de/otto/tesla/xray/xraychecker_test.clj
@@ -159,11 +159,12 @@
                  @(:check-results xray-checker)))
 
           ;ACKNOWLEDGE!
-          (is (= 200 (-> (handler-fn (mock/request :post (str "/xray-checker/acknowledged-checks?check-name=ErrorCheck&environment=dev&hours=" acknowledge-hours)))
+          (is (= 204 (-> (handler-fn (mock/request :post (str "/xray-checker/acknowledged-checks?check-name=ErrorCheck&environment=dev&hours=" acknowledge-hours)))
                          :status)))
           ;acknowledged results
           (start-the-xraychecks xray-checker)
-          (is (= {"ErrorCheck" {"dev" (+ acknowledge-hours-in-millis current-time)}} @(:acknowledged-checks xray-checker)))
+          (is (= {"ErrorCheck" {"dev" (+ acknowledge-hours-in-millis current-time)}}
+                 @(:acknowledged-checks xray-checker)))
           (is (= {"ErrorCheck" {"dev" {:overall-status :acknowledged
                                        :results        [(chk/->XRayCheckResult :acknowledged "error-message; Acknowledged" 0 10)
                                                         (chk/->XRayCheckResult :error "error-message" 0 10)]}}}
@@ -185,11 +186,12 @@
       (try
         (with-redefs [utils/current-time (constantly start-time)]
           ;ACKNOWLEDGE!
-          (is (= 200 (-> (handler-fn (mock/request :post (str "/xray-checker/acknowledged-checks?check-name=ErrorCheck&environment=dev&hours=" acknowledge-hours)))
+          (is (= 204 (-> (handler-fn (mock/request :post (str "/xray-checker/acknowledged-checks?check-name=ErrorCheck&environment=dev&hours=" acknowledge-hours)))
                          :status)))
           ;acknowledged results
           (start-the-xraychecks xray-checker)
-          (is (= {"ErrorCheck" {"dev" (+ acknowledge-hours-in-millis start-time)}} @(:acknowledged-checks xray-checker)))
+          (is (= {"ErrorCheck" {"dev" (+ acknowledge-hours-in-millis start-time)}}
+                 @(:acknowledged-checks xray-checker)))
           (is (= {"ErrorCheck" {"dev" {:overall-status :acknowledged
                                        :results        [(chk/->XRayCheckResult :acknowledged "error-message; Acknowledged" 0 start-time)]}}}
                  @(:check-results xray-checker))))
@@ -218,11 +220,11 @@
       (try
         (with-redefs [utils/current-time (constantly start-time)]
           ;ACKNOWLEDGE!
-          (is (= 200 (-> (handler-fn (mock/request :post (str "/xray-checker/acknowledged-checks?check-name=ErrorCheck&environment=dev&hours=" acknowledge-hours)))
+          (is (= 204 (-> (handler-fn (mock/request :post (str "/xray-checker/acknowledged-checks?check-name=ErrorCheck&environment=dev&hours=" acknowledge-hours)))
                          :status)))
           (is (= {"ErrorCheck" {"dev" (+ acknowledge-hours-in-millis start-time)}} @(:acknowledged-checks xray-checker)))
           ;DELETE ACKNOWLEDGEMENT!
-          (is (= 200 (-> (handler-fn (mock/request :delete "/xray-checker/acknowledged-checks/ErrorCheck/dev"))
+          (is (= 204 (-> (handler-fn (mock/request :delete "/xray-checker/acknowledged-checks/ErrorCheck/dev"))
                          :status)))
           (is (= {} @(:acknowledged-checks xray-checker))))
         (finally

--- a/test/de/otto/tesla/xray/xraychecker_test.clj
+++ b/test/de/otto/tesla/xray/xraychecker_test.clj
@@ -306,6 +306,11 @@
           (finally
             (comp/stop started)))))))
 
+(deftest stringify-acknowledged-checks-test
+  (testing "should format timestamp properly"
+    (is (= "{\"testCheck\":{\"dev\":\"1 November, 09:27\"}}"
+           (chkr/stringify-acknowledged-checks (atom {"testCheck" {"dev" 1477988830064}}))))))
+
 (deftest acknowledge-check-endpoints
   (testing "should put a check object with correct expire time in the acknowledged-checks atom"
     (with-redefs [utils/current-time (constantly 10)]

--- a/test/de/otto/tesla/xray/xraychecker_test.clj
+++ b/test/de/otto/tesla/xray/xraychecker_test.clj
@@ -151,7 +151,7 @@
           (swap! (:acknowledged-checks xray-checker) assoc-in ["ErrorCheck" "dev"] 15)
           (start-the-xraychecks xray-checker)
           (is (= {"ErrorCheck" {"dev" {:overall-status :acknowledged
-                                       :results        [(chk/->XRayCheckResult :error "error-message" 0 10)
+                                       :results        [(chk/->XRayCheckResult :acknowledged "error-message; Acknowledged" 0 10)
                                                         (chk/->XRayCheckResult :error "error-message" 0 10)]}}}
                  @(:check-results xray-checker))))
 
@@ -162,7 +162,7 @@
                  @(:acknowledged-checks xray-checker)))
           (is (= {"ErrorCheck" {"dev" {:overall-status :error
                                        :results        [(chk/->XRayCheckResult :error "error-message" 0 20)
-                                                        (chk/->XRayCheckResult :error "error-message" 0 10)]}}}
+                                                        (chk/->XRayCheckResult :acknowledged "error-message; Acknowledged" 0 10)]}}}
                  @(:check-results xray-checker))))
         (finally
           (comp/stop started))))))

--- a/test/de/otto/tesla/xray/xraychecker_test.clj
+++ b/test/de/otto/tesla/xray/xraychecker_test.clj
@@ -351,3 +351,17 @@
               [check-b "dev"] [check-b "test"]]
              (build-check-name-env-vecs ["dev" "test"] {"CheckA" check-a
                                                         "CheckB" check-b}))))))
+
+
+(deftest clear-outdated-acknowledgements!
+  (testing "should clear outdated acknowledgements"
+    (with-redefs [utils/current-time (constantly 20)]
+      (let [state (atom {"CheckA" {"dev"  20
+                                   "prod" 30}
+                         "CheckB" {"dev"  30
+                                   "prod" 10}
+                         "CheckC" {"prod" 10}})]
+        (chkr/clear-outdated-acknowledgements! {:acknowledged-checks state})
+        (is (= {"CheckA" {"prod" 30}
+                "CheckB" {"dev" 30}}
+               @state))))))

--- a/test/de/otto/tesla/xray/xraychecker_test.clj
+++ b/test/de/otto/tesla/xray/xraychecker_test.clj
@@ -9,7 +9,8 @@
     [com.stuartsierra.component :as c]
     [de.otto.tesla.xray.util.utils :as utils]
     [de.otto.tesla.stateful.handler :as handler]
-    [ring.mock.request :as mock]))
+    [ring.mock.request :as mock])
+  (:import (org.joda.time DateTimeZone DateTime)))
 
 (defrecord DummyCheck []
   chk/XRayCheck
@@ -308,8 +309,9 @@
 
 (deftest stringify-acknowledged-checks-test
   (testing "should format timestamp properly"
-    (is (= "{\"testCheck\":{\"dev\":\"1 November, 09:27\"}}"
-           (chkr/stringify-acknowledged-checks (atom {"testCheck" {"dev" 1477988830064}}))))))
+    (with-redefs [chkr/as-date-time (fn [millis] (DateTime. millis DateTimeZone/UTC))]
+      (is (= "{\"testCheck\":{\"dev\":\"1 November, 08:27\"}}"
+             (chkr/stringify-acknowledged-checks (atom {"testCheck" {"dev" 1477988830064}})))))))
 
 (deftest acknowledge-check-endpoints
   (testing "should put a check object with correct expire time in the acknowledged-checks atom"

--- a/test/de/otto/tesla/xray/xraychecker_test.clj
+++ b/test/de/otto/tesla/xray/xraychecker_test.clj
@@ -254,20 +254,20 @@
   (testing "should put a check object with correct expire time in the acknowledged-checks atom"
     (with-redefs [utils/current-time (constantly 10)]
       (let [acknowledged-checks (atom {})]
-        (chkr/acknowledge-check! (atom {}) acknowledged-checks "oneHourAcknowledgement" "test-env" "60")
+        (chkr/acknowledge-check! (atom {}) acknowledged-checks "oneHourAcknowledgement" "test-env" "1")
         (is (= ["oneHourAcknowledgement" {"test-env" (+ 10 (* 60 60 1000))}] (first @acknowledged-checks))))))
 
   (testing "should keep other environments unchanged when adding ack for same check in different env"
     (with-redefs [utils/current-time (constantly 10)]
       (let [acknowledged-checks (atom {"oneHourAcknowledgement" {"otherEnv" 20}})]
-        (chkr/acknowledge-check! (atom {}) acknowledged-checks "oneHourAcknowledgement" "test-env" "60")
+        (chkr/acknowledge-check! (atom {}) acknowledged-checks "oneHourAcknowledgement" "test-env" "1")
         (is (= ["oneHourAcknowledgement" {"test-env" (+ 10 (* 60 60 1000))
                                           "otherEnv" 20}] (first @acknowledged-checks))))))
 
   (testing "should immediatly change the overall status to acknowledged"
     (let [acknowledged-checks (atom {})
           check-results (atom {"testCheck" {"test-env" {:overall-status :error}}})]
-      (chkr/acknowledge-check! check-results acknowledged-checks "testCheck" "test-env" "60")
+      (chkr/acknowledge-check! check-results acknowledged-checks "testCheck" "test-env" "1")
       (is (= {"testCheck" {"test-env" {:overall-status :acknowledged}}}
              @check-results))))
 


### PR DESCRIPTION
You are now able to acknowledge checks that have an error by clicking on the check header in the detail view. Acknowledgement lasts until it expires (default: one day) or the check turns ok again.

Acknowledgement duration can be configured by setting `:<xray-checker-name>-acknowledge-hours-to-expire 1` in the configuration.

New endpoints for acknowledgement feature:
- `/acknowledged-checks` GET: show all acknowledged checks and the unix time stamp when they expire
- `/acknowledged-checks` POST: set new acknowledgement, parameters are: 
  *\* `check-name` name of check to acknowledge
  *\* `environment` where the check should be acknowledged
  *\* `hours` how long the acknowledgement should last (in hours)
- `/acknowledged-checks/<check-name>/<environment>` DELETE: delete acknowledgement for the check and environment specified in url
