### PR TITLE
Do not wrap the detail result container with <a>

### DIFF
--- a/src/de/otto/tesla/xray/ui/check_overview.clj
+++ b/src/de/otto/tesla/xray/ui/check_overview.clj
@@ -6,27 +6,26 @@
 
 (defn- single-result [{:keys [status message time-taken stop-time]}]
   [:div.result.status {:class (name status)}
-   (or (uu/readable-timestamp stop-time) "") 
-   "tt:" 
+   (or (uu/readable-timestamp stop-time) "")
+   "tt:"
    time-taken
    message])
 
-(defn results-for-env [nr-checks-displayed check-id endpoint [env {:keys [results overall-status]}]]
+(defn results-for-env [nr-checks-displayed [env {:keys [results overall-status]}]]
   (let [url-encoded-env (co/url-encode env)]
     [:div.env-result.status {:class (name overall-status)}
-     [:a {:href (str endpoint "/checks/" check-id "/" url-encoded-env)}
-      [:div
-       [:header env]
-       (for [r (take nr-checks-displayed results)]
-         (single-result r))]]]))
+     [:div
+      [:header env]
+      (for [r (take nr-checks-displayed results)]
+        (single-result r))]]))
 
-(defn- envs-for-check [registered-checks {:keys [environments nr-checks-displayed endpoint]} [check-id results-for-check]]
+(defn- envs-for-check [registered-checks {:keys [environments nr-checks-displayed]} [check-id results-for-check]]
   (let [sorted-results (uu/sort-results-by-env results-for-check environments)]
     [:article.check
      [:header (get-in registered-checks [check-id :title])]
      (into [:div.results]
            (for [r sorted-results]
-             (results-for-env nr-checks-displayed check-id endpoint r)))]))
+             (results-for-env nr-checks-displayed r)))]))
 
 (defn summarize-ok-checks [registered-checks xray-config ok-checks]
   [:article.check

--- a/src/de/otto/tesla/xray/ui/detail_page.clj
+++ b/src/de/otto/tesla/xray/ui/detail_page.clj
@@ -20,19 +20,19 @@
   (let [end-time (get-in @acknowledged-checks [check-id current-env])]
     [:section.acknowledge
      [:header "Acknowledgement"]
-     
+
      (if end-time
        [:div
         [:div
          [:span.label "active since:"]
          [:span.value (uu/readable-timestamp end-time)]]
-        [:div 
+        [:div
          [:span.label "time left:"]
          [:span.value (uu/time-left end-time)]]]
        [:div
         [:span.value "Not acknowlegded"]])
 
-     (if end-time 
+     (if end-time
        (del-form endpoint check-id current-env)
        (ack-form endpoint check-id current-env acknowledge-hours-to-expire))]))
 
@@ -42,7 +42,7 @@
      [:article.check
       (acknowledge-section acknowledged-checks acknowledge-hours-to-expire endpoint check-id current-env)
       [:div.results
-       (eo/results-for-env max-check-history check-id endpoint [current-env check-results])]]]
+       (eo/results-for-env max-check-history [current-env check-results])]]]
     [:div "NO DATA FOUND"]))
 
 (defn detail-page [{:keys [registered-checks check-results acknowledged-checks xray-config]} check-id current-env]


### PR DESCRIPTION
Why does the whole result container on the detail page need to be within an a tag that links to the detail page itself?

This would better off without a link on itself so you could link inside the container in your error messages and actually make the content of the detail page able to be marked.