### PR TITLE
Fix reset acknowledgement button

### DIFF
--- a/resources/public/js/application.js
+++ b/resources/public/js/application.js
@@ -27,3 +27,18 @@ function successListener() {
 function errorListener() {
     console.error(this.responseText);
 }
+
+function deleteAcknowledgement(xrayUrl, check, environment) {
+    console.log("HELLO I WAS CALLED");
+    var http = new XMLHttpRequest();
+    console.log(xrayUrl + '/acknowledged-checks/'+ check+ '/'+environment);
+    http.open('DELETE', xrayUrl + '/acknowledged-checks/'+ check+ '/'+environment);
+    http.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+
+    http.onreadystatechange = function () {
+        if (http.readyState == 4) {
+            location.reload();
+        }
+    };
+    http.send();
+}

--- a/resources/public/js/application.js
+++ b/resources/public/js/application.js
@@ -29,7 +29,6 @@ function errorListener() {
 }
 
 function deleteAcknowledgement(xrayUrl, check, environment) {
-    console.log("HELLO I WAS CALLED");
     var http = new XMLHttpRequest();
     console.log(xrayUrl + '/acknowledged-checks/'+ check+ '/'+environment);
     http.open('DELETE', xrayUrl + '/acknowledged-checks/'+ check+ '/'+environment);

--- a/src/de/otto/tesla/xray/ui/detail_page.clj
+++ b/src/de/otto/tesla/xray/ui/detail_page.clj
@@ -12,9 +12,9 @@
    [:input {:type "submit" :value "ack"}]])
 
 (defn del-form [endpoint check-id current-env]
-  [:form {:data-method "DELETE" :action (str endpoint "/acknowledged-checks/" check-id "/" current-env) :id "del-ack"}
+  [:form {:id "del-ack"}
    [:div [:span.label "Reset acknowlegment:"]]
-   [:input {:type "submit" :value "reset"}]])
+   [:input {:type "submit" :value "reset" :on-click (format "deleteAcknowledgement(%s, %s, %s)" endpoint check-id current-env)}]])
 
 (defn acknowledge-section [acknowledged-checks acknowledge-hours-to-expire endpoint check-id current-env]
   (let [end-time (get-in @acknowledged-checks [check-id current-env])]


### PR DESCRIPTION
Pressing the reset button led the browser navigate to the /acknowledged-checks/... endpoint (at least for some browsers) which does not support GET requests. Reloading the detail page is the correct behaviour instead.